### PR TITLE
Add Dockerfile and script to run api server in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM krig/crmsh
+WORKDIR /app
+RUN zypper -n install nodejs8 npm8
+RUN npm install yarn
+CMD ["sh", "./cboot.sh"]

--- a/cboot.sh
+++ b/cboot.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# boot inside container
+# to start API
+#
+# to build the container:
+# docker build --tag=hawk-web-client .
+# to launch the container, run
+# docker run -it -p 3004:3004/tcp -v "$(pwd):/app" hawk-web-client
+
+export PATH="$(npm bin):$PATH"
+yarn install
+yarn run api


### PR DESCRIPTION
Helper scripts to run the api server in a docker container:

To build the container, run

```
docker build --tag=hawk-web-client .
```

To start the server, run

```
docker run -it -p 3004:3004/tcp -v "$(pwd):/app" hawk-web-client
```
